### PR TITLE
tried to add hPref to proper nouns; does not work

### DIFF
--- a/src/np-lex-cc.txt
+++ b/src/np-lex-cc.txt
@@ -144,6 +144,7 @@ LEXICON NpSéUrú
 +Com+Sg:	#; 
 +Gen+Sg+Len:^IM^Sé		#; 
 +Gen+Pl+Ecl:^IM^Urú		#;
++Com+Sg+hPref:^IM^hve		#;  ! le hAaron
 
 LEXICON NpSéUrú-EN
 +Com+Sg:	#; 


### PR DESCRIPTION
@uidhonne - masculine proper nouns beginning with vowels seem to be lacking hPref forms: when I try to analyse something like "dár le hAlan Titley" or "agus ansin le hAaron Burr" (both pieces from Wikipedia), I get unknown marks. I tried this change, but it didn't make a difference. Is there something else I should be doing first, or instead?
